### PR TITLE
Add git ignore file

### DIFF
--- a/hiring-copilot-frontend/.gitignore
+++ b/hiring-copilot-frontend/.gitignore
@@ -1,0 +1,21 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Dependencies
+node_modules/
+
+# Build artifacts
+/dist
+/build
+
+# OS and IDE files
+.DS_Store
+.vscode/
+.idea/
+*.swp
+*.swo
+*~


### PR DESCRIPTION
Node module dependencies were showing up as changes in the Git project, so I added a .gitignore file to exclude them along with other typical frontend-generated files.