### PR TITLE
ISSUE #54 - Examples of L1 questions based on gaps

### DIFF
--- a/hiring-copilot-data/Fabian/ai_service/examples/example_L1_gap_questions.md
+++ b/hiring-copilot-data/Fabian/ai_service/examples/example_L1_gap_questions.md
@@ -1,0 +1,63 @@
+# Ejemplos de Preguntas L1 basadas en Gaps (ISSUE #54)
+
+Este archivo contiene ejemplos de preguntas L1 generadas a partir de gaps detectados entre un Job Description (JD) y un CV.
+
+---
+
+## Ejemplo 1 – Backend Developer
+
+**Gaps detectados:**
+- Falta de experiencia con TypeScript.
+- Poca experiencia con testing automatizado.
+- Python usado más para análisis que para backend.
+
+**Preguntas L1 basadas en esos gaps:**
+
+1. Veo que tu experiencia con TypeScript es limitada. ¿Cómo planearías aprenderlo rápidamente para integrarte a un equipo que lo usa como estándar?
+   - _Evalúa capacidad de aprendizaje y adaptación._
+
+2. En el JD se menciona testing automatizado. ¿Cómo validarías una API REST si todavía no dominás un framework de tests?
+   - _Evalúa criterio práctico ante un gap técnico._
+
+3. Has usado Python principalmente para análisis. ¿Qué pasos seguirías para usarlo de forma más sólida en un contexto de backend?
+   - _Evalúa cómo el candidato piensa cerrar una brecha de uso real._
+
+---
+
+## Ejemplo 2 – Data Analyst
+
+**Gaps detectados:**
+- Sin experiencia formal en modelado de datos.
+- SQL a nivel intermedio.
+- Poca exposición a grandes volúmenes de datos.
+
+**Preguntas L1:**
+
+1. ¿Cómo diseñarías, aunque sea a alto nivel, un modelo de datos tipo “star schema” para un dashboard de ventas?
+   - _Explora el gap en modelado y su capacidad de razonar el diseño._
+
+2. Si una consulta SQL te devuelve más filas de las esperadas por culpa de un JOIN, ¿cómo la depurarías?
+   - _Evalúa capacidad de diagnóstico con SQL intermedio._
+
+3. Nunca has trabajado con datasets muy grandes. ¿Qué estrategias seguirías para empezar a trabajar con datos de más de 10M de registros?
+   - _Explora cómo el candidato enfrenta la escalabilidad aunque no la haya vivido._
+
+---
+
+## Ejemplo 3 – Frontend Developer (React)
+
+**Gaps detectados:**
+- Poco dominio de TypeScript.
+- Testing muy básico.
+- Experiencia limitada en manejo de estado global.
+
+**Preguntas L1:**
+
+1. Dado que tu experiencia con TypeScript es limitada, ¿cómo asegurarías un buen tipado en un formulario complejo?
+   - _Explora el gap técnico en TS y cómo lo abordaría._
+
+2. ¿Qué probarías primero en un componente clave si aún no dominás Jest u otra herramienta de testing?
+   - _Explora criterio de testing aun con experiencia limitada._
+
+3. Si tuvieras que manejar el estado global de una SPA sin haber usado Redux/Zustand, ¿cómo lo encararías?
+   - _Evalúa cómo piensa resolver un problema de arquitectura que todavía no domina._


### PR DESCRIPTION
Adds examples of L1 interview questions based on gaps identified between Job Description and CV for the AI role (Issue #54).

File added:
- hiring-copilot-data/Fabian/ai_service/examples/example_L1_gap_questions.md

This includes:
- 3 role-specific examples (Backend, Data Analyst, Frontend)
- Gaps identified per role
- L1 questions tied directly to those gaps
