### PR TITLE
ISSUE #55 - Anti-AI thinking assignment example

### DIFF
--- a/hiring-copilot-data/Fabian/ai_service/examples/example_anti_ai_assignment.md
+++ b/hiring-copilot-data/Fabian/ai_service/examples/example_anti_ai_assignment.md
@@ -1,0 +1,56 @@
+# Anti-AI Thinking Assignment – Ejemplo #2  
+Evaluación de razonamiento, trade-offs y toma de decisiones bajo restricciones
+
+---
+
+## Contexto del rol
+**Rol:** Full-Stack Developer (React + .NET)  
+**Objetivo:** Evaluinar criterio técnico, priorización y razonamiento conceptual sin depender de código.
+
+---
+
+## Título
+Diseño de un módulo de “Aplicación de Vacantes” bajo restricciones reales de negocio
+
+---
+
+## Enunciado para el candidato
+
+Su equipo debe construir un módulo donde los candidatos puedan aplicar a un puesto, adjuntar un CV y completar un formulario básico.
+
+Pero existen **tres restricciones fuertes**:
+
+1. Tiempo máximo para entregar una primera versión funcional: **5 días**.  
+2. El equipo de backend solo puede apoyarte **8 horas** en total.  
+3. La solución debe ser flexible para integrar un motor de IA más adelante (pero **no ahora**).
+
+Su tarea es responder lo siguiente:
+
+---
+
+## 1. Decisiones de arquitectura
+- ¿Qué componentes construirías en esta primera versión?
+- ¿Qué dejarías fuera y por qué?
+- ¿Qué parte del sistema diseñarías con mayor flexibilidad pensando en IA futura?
+
+---
+
+## 2. Priorización
+- Si solo podés entregar **3 funcionalidades indispensables**, ¿cuáles son?
+- Explicá los **criterios** que usaste para priorizar.
+
+---
+
+## 3. Estrategia para manejar la dependencia con backend
+El backend solo tiene **8 horas disponibles**.
+
+- ¿Qué trabajo debería hacer backend?
+- ¿Qué trabajo tomarías vos
+
+## Qué evalúa esta tarea
+- Priorización bajo presión  
+- Pensamiento crítico y toma de decisiones  
+- Diseño conceptual  
+- Identificación de riesgos reales  
+- Comunicación clara  
+- Razonamiento propio, no output generado por IA  


### PR DESCRIPTION
Adds a second anti-AI thinking assignment example for the AI/Data role (Issue #55).

File added:
- hiring-copilot-data/Fabian/ai_service/examples/example_anti_ai_assignment.md

The assignment focuses on:
- Conceptual design of a “Job Application” module under real-world constraints
- Prioritization and trade-offs (time vs robustness, flexibility vs speed)
- Reasoning and decision-making, not code
